### PR TITLE
Added empty folder LIB/

### DIFF
--- a/LIB/README
+++ b/LIB/README
@@ -1,0 +1,1 @@
+This empty folder is assumed by the Makefile. After compilation you will find here the library.

--- a/SRC/pmrrr.c
+++ b/SRC/pmrrr.c
@@ -555,8 +555,8 @@ double scale_matrix(in_t *Dstruct, val_t *Wstruct, bool valeig)
   if (scale != 1.0) {  /* FP cmp okay */
     /* Scale matrix and matrix norm */
     itmp = n-1;
-    dscal_(&n,    &scale, D, &IONE);
-    dscal_(&itmp, &scale, E, &IONE);
+    odscl_(&n,    &scale, D, &IONE);
+    odscl_(&itmp, &scale, E, &IONE);
     if (valeig == true) {
       /* Scale eigenvalue bounds */
       *vl *= scale;
@@ -586,7 +586,7 @@ void invscale_eigenvalues(val_t *Wstruct, double scale,
   if (scale != 1.0) {  /* FP cmp okay */
     *vl *= invscale;
     *vu *= invscale;
-    dscal_(&size, &invscale, W, &IONE);
+    odscl_(&size, &invscale, W, &IONE);
   }
 }
 


### PR DESCRIPTION
At the moment you will get an error during compilation, because the Makefile assumes the empty folder LIB. After compilation you will find here the library. However, you can't add an empty folder to git. See the [Git FAQ](https://git.wiki.kernel.org/index.php/GitFaq#Can_I_add_empty_directories.3F).

In this Pull request I have added the folder a LIB and a short README file within this folder.

Second commit: At the moment the library is not running (try to run the examples), since the function dscale_ is not defined. The function name should be odscl_.
